### PR TITLE
Correct syntax for cryptfs changepw

### DIFF
--- a/CryptCommandListener.cpp
+++ b/CryptCommandListener.cpp
@@ -263,7 +263,7 @@ int CryptCommandListener::CryptfsCmd::runCommand(SocketClient *cli,
     } else if (subcommand == "changepw") {
         const char* syntax = "Usage: cryptfs changepw "
                              "default|password|pin|pattern [currentpasswd] "
-                             "default|password|pin|pattern [newpasswd]";
+                             "[newpasswd]";
         const char* password;
         const char* currentpassword;
         if (argc == 4) {


### PR DESCRIPTION
Syntax hinting was wrong. The method never accesses the last parameter and used the type instead as a password. It does work without the second type parameter though.
I tried fixing it, i do not have a build environment though, so please review and merge it if you want to.